### PR TITLE
Update README.md to explicitly say publishing the configuration is a must

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Easily manage Expo notifications with Laravel. Support batched notifications.
 
 ## Configure
 
-You can publish the configuration file with:
+You must publish the configuration file with:
 
 ```shell
 php artisan vendor:publish --provider="YieldStudio\LaravelExpoNotifier\ExpoNotificationsServiceProvider" --tag="expo-notifications-config" --tag="expo-notifications-migration"


### PR DESCRIPTION
Currently, the readme make it sound like publishing the config is optional.
However, attempts to send a notification prior to that step results in:
`Target [YieldStudio\LaravelExpoNotifier\Contracts\ExpoPendingNotificationStorageInterface] is not instantiable while building [App\Console\Commands\DebugCommand, YieldStudio\LaravelExpoNotifier\ExpoNotificationsChannel].`