### PR TITLE
bugfix: adds tests and fix bug sending more than 100 not batched notifications 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
   "require-dev": {
     "ciareis/bypass": "^1.0",
     "dg/bypass-finals": "^1.4",
+    "guzzlehttp/guzzle": "^7.8",
     "laravel/pint": "^1.3",
     "orchestra/testbench": "7.*|8.*",
     "pestphp/pest": "^1.21",

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
   "require": {
     "php": "^8.1",
     "illuminate/database": "^9|^10",
-    "illuminate/support": "^9|^10"
+    "illuminate/support": "^9|^10",
+    "nesbot/carbon": ">=2.62.1"
   },
   "require-dev": {
     "ciareis/bypass": "^1.0",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -19,4 +19,9 @@
             <directory>src/</directory>
         </whitelist>
     </filter>
+    <php>
+        <env name="APP_KEY" value="AckfSECXIvnK5r28GVIWUAxmbBSjTsmF"/>
+        <env name="DB_CONNECTION" value="testing"/>
+        <env name="ENABLE_HTTPS_SUPPORT" value="false"/>
+    </php>
 </phpunit>

--- a/src/Contracts/ExpoNotificationsServiceInterface.php
+++ b/src/Contracts/ExpoNotificationsServiceInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YieldStudio\LaravelExpoNotifier\Contracts;
+
+use Illuminate\Support\Collection;
+use YieldStudio\LaravelExpoNotifier\Dto\ExpoMessage;
+
+interface ExpoNotificationsServiceInterface
+{
+    public function __construct(
+        string $apiUrl,
+        string $host,
+        ExpoPendingNotificationStorageInterface $notificationStorage,
+        ExpoTicketStorageInterface $ticketStorage
+    );
+
+    public function notify(ExpoMessage|Collection|array $expoMessages): Collection;
+
+    public function receipts(Collection|array $tokenIds): Collection;
+
+    public function getNotificationChunks(): Collection;
+}

--- a/src/ExpoNotificationsChannel.php
+++ b/src/ExpoNotificationsChannel.php
@@ -5,13 +5,14 @@ declare(strict_types=1);
 namespace YieldStudio\LaravelExpoNotifier;
 
 use Illuminate\Notifications\Notification;
+use YieldStudio\LaravelExpoNotifier\Contracts\ExpoNotificationsServiceInterface;
 use YieldStudio\LaravelExpoNotifier\Dto\ExpoMessage;
 use YieldStudio\LaravelExpoNotifier\Exceptions\ExpoNotificationsException;
 
 final class ExpoNotificationsChannel
 {
     public function __construct(
-        protected readonly ExpoNotificationsService $expoNotificationsService,
+        protected readonly ExpoNotificationsServiceInterface $expoNotificationsService,
     ) {
     }
 

--- a/src/ExpoNotificationsService.php
+++ b/src/ExpoNotificationsService.php
@@ -150,7 +150,6 @@ final class ExpoNotificationsService implements ExpoNotificationsServiceInterfac
         // Splits into multiples chunks of max limitation
         $this->notificationChunks = $this->notificationsToSend->chunk(self::PUSH_NOTIFICATIONS_PER_REQUEST_LIMIT);
 
-
         return $this;
     }
 

--- a/src/ExpoNotificationsService.php
+++ b/src/ExpoNotificationsService.php
@@ -150,7 +150,6 @@ final class ExpoNotificationsService implements ExpoNotificationsServiceInterfac
         // Splits into multiples chunks of max limitation
         $this->notificationChunks = $this->notificationsToSend->chunk(self::PUSH_NOTIFICATIONS_PER_REQUEST_LIMIT);
 
-        $this->checkAndStoreTickets($this->notificationsToSend->pluck('to')->flatten());
 
         return $this;
     }

--- a/src/ExpoNotificationsServiceProvider.php
+++ b/src/ExpoNotificationsServiceProvider.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
 use YieldStudio\LaravelExpoNotifier\Commands\CheckTickets;
 use YieldStudio\LaravelExpoNotifier\Commands\SendPendingNotifications;
+use YieldStudio\LaravelExpoNotifier\Contracts\ExpoNotificationsServiceInterface;
 use YieldStudio\LaravelExpoNotifier\Contracts\ExpoPendingNotificationStorageInterface;
 use YieldStudio\LaravelExpoNotifier\Contracts\ExpoTicketStorageInterface;
 use YieldStudio\LaravelExpoNotifier\Contracts\ExpoTokenStorageInterface;
@@ -22,7 +23,7 @@ final class ExpoNotificationsServiceProvider extends ServiceProvider
         $this->app->bind(ExpoTicketStorageInterface::class, config('expo-notifications.drivers.ticket'));
         $this->app->bind(ExpoPendingNotificationStorageInterface::class, config('expo-notifications.drivers.notification'));
 
-        $this->app->bind(ExpoNotificationsService::class, function ($app) {
+        $this->app->bind(ExpoNotificationsServiceInterface::class, function ($app) {
             $apiUrl = config('expo-notifications.service.api_url');
             $host = config('expo-notifications.service.host');
 

--- a/src/FakeExpoNotificationsService.php
+++ b/src/FakeExpoNotificationsService.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YieldStudio\LaravelExpoNotifier;
+
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
+use YieldStudio\LaravelExpoNotifier\Contracts\ExpoNotificationsServiceInterface;
+use YieldStudio\LaravelExpoNotifier\Contracts\ExpoPendingNotificationStorageInterface;
+use YieldStudio\LaravelExpoNotifier\Contracts\ExpoTicketStorageInterface;
+use YieldStudio\LaravelExpoNotifier\Dto\ExpoMessage;
+use YieldStudio\LaravelExpoNotifier\Dto\PushTicketResponse;
+use YieldStudio\LaravelExpoNotifier\Enums\ExpoResponseStatus;
+use YieldStudio\LaravelExpoNotifier\Events\InvalidExpoToken;
+use YieldStudio\LaravelExpoNotifier\Exceptions\ExpoNotificationsException;
+
+/**
+ * Fake Expo Notification service to avoid real API calls while coding the feature.
+ * If you want to tests against the real API, you can swap the ExpoNotificationsServiceInterface binding in TestCase
+ */
+final class FakeExpoNotificationsService implements ExpoNotificationsServiceInterface
+{
+    public const PUSH_NOTIFICATIONS_PER_REQUEST_LIMIT = 100;
+
+    private ?Collection $expoMessages;
+
+    private ?Collection $notificationsToSend;
+
+    private Collection $tickets;
+
+    private ?Collection $notificationChunks;
+
+    public function __construct(
+        string $apiUrl,
+        string $host,
+        /* @phpstan-ignore-next-line */
+        private readonly ExpoPendingNotificationStorageInterface $notificationStorage,
+        /* @phpstan-ignore-next-line */
+        private readonly ExpoTicketStorageInterface $ticketStorage
+    ) {
+        $this->tickets = collect();
+    }
+
+    public function notify(ExpoMessage|Collection|array $expoMessages): Collection
+    {
+        /** @var Collection<int, ExpoMessage> $expoMessages */
+        $this->expoMessages = $expoMessages instanceof Collection ? $expoMessages : collect(Arr::wrap($expoMessages));
+
+        return $this->storeNotificationsToSendInTheNextBatch()
+            ->prepareNotificationsToSendNow()
+            ->sendNotifications();
+    }
+
+    public function receipts(array|Collection $tokenIds): Collection
+    {
+        // TODO: Implement receipts() method.
+    }
+
+    public function getNotificationChunks(): Collection
+    {
+        return $this->notificationChunks ?? collect();
+    }
+
+    private function prepareNotificationsToSendNow(): FakeExpoNotificationsService
+    {
+        $this->notificationsToSend = $this->expoMessages
+            ->reject(fn (ExpoMessage $message) => $message->shouldBatch)
+            ->map(fn (ExpoMessage $message) => $message->toExpoData())
+            ->values();
+
+        // Splits into multiples chunks of max limitation
+        $this->notificationChunks = $this->notificationsToSend->chunk(self::PUSH_NOTIFICATIONS_PER_REQUEST_LIMIT);
+
+        return $this;
+    }
+
+    private function storeNotificationsToSendInTheNextBatch(): FakeExpoNotificationsService
+    {
+        $this->expoMessages
+            ->filter(fn (ExpoMessage $message) => $message->shouldBatch)
+            ->each(fn (ExpoMessage $message) => $this->notificationStorage->store($message));
+
+        return $this;
+    }
+
+    private function sendNotifications(): Collection
+    {
+        if ($this->notificationsToSend->isEmpty()) {
+            return collect();
+        }
+
+        $this->notificationChunks
+            ->each(
+                fn ($chunk, $index) => $this->sendNotificationsChunk($chunk->toArray(), $index)
+            );
+
+        $this->checkAndStoreTickets($this->notificationsToSend->pluck('to')->flatten());
+
+        return $this->tickets;
+    }
+
+    private function sendNotificationsChunk(array $chunk, int $chunkId): void
+    {
+        $data = [];
+        foreach ($chunk as $notification) {
+            $data[] = [
+                'id' => Str::orderedUuid()->toString(),
+                'status' => ExpoResponseStatus::OK->value,
+                '__notification' => $notification,
+            ];
+        }
+
+        $response = Http::fake([
+            'api-push/'.$chunkId => Http::response([
+                'data' => $data,
+            ]),
+        ])->get('/api-push/'.$chunkId);
+
+        if (! $response->successful()) {
+            throw new ExpoNotificationsException($response->toPsrResponse());
+        }
+
+        $this->handleSendNotificationsResponse($response);
+    }
+
+    private function handleSendNotificationsResponse(Response $response): void
+    {
+        $data = json_decode($response->body(), true, 512, JSON_THROW_ON_ERROR);
+        if (! empty($data['errors'])) {
+            throw new ExpoNotificationsException($response->toPsrResponse());
+        }
+
+        $this->setTicketsFromData($data);
+    }
+
+    private function setTicketsFromData(array $data): FakeExpoNotificationsService
+    {
+        collect($data['data'])
+            ->each(function ($responseItem) {
+                if ($responseItem['status'] === ExpoResponseStatus::ERROR->value) {
+                    $this->tickets->push(
+                        (new PushTicketResponse())
+                            ->status($responseItem['status'])
+                            ->message($responseItem['message'])
+                            ->details($responseItem['details'])
+                    );
+                } else {
+                    $this->tickets->push(
+                        (new PushTicketResponse())
+                            ->status($responseItem['status'])
+                            ->ticketId($responseItem['id'])
+                    );
+                }
+            });
+
+        return $this;
+    }
+
+    /**
+     * @param  Collection<int, string>  $tokens
+     */
+    private function checkAndStoreTickets(Collection $tokens): void
+    {
+        $this->tickets
+            ->intersectByKeys($tokens)
+            ->each(function (PushTicketResponse $ticket, $index) use ($tokens) {
+                if ($ticket->status === ExpoResponseStatus::ERROR->value) {
+                    if (
+                        is_array($ticket->details) &&
+                        array_key_exists('error', $ticket->details) &&
+                        $ticket->details['error'] === ExpoResponseStatus::DEVICE_NOT_REGISTERED->value
+                    ) {
+                        event(new InvalidExpoToken($tokens->get($index)));
+                    }
+                } else {
+                    $this->ticketStorage->store($ticket->ticketId, $tokens->get($index));
+                }
+            });
+    }
+}

--- a/src/Jobs/CheckTickets.php
+++ b/src/Jobs/CheckTickets.php
@@ -8,11 +8,11 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Collection;
+use YieldStudio\LaravelExpoNotifier\Contracts\ExpoNotificationsServiceInterface;
 use YieldStudio\LaravelExpoNotifier\Contracts\ExpoTicketStorageInterface;
 use YieldStudio\LaravelExpoNotifier\Dto\ExpoTicket;
 use YieldStudio\LaravelExpoNotifier\Enums\ExpoResponseStatus;
 use YieldStudio\LaravelExpoNotifier\Events\InvalidExpoToken;
-use YieldStudio\LaravelExpoNotifier\ExpoNotificationsService;
 
 class CheckTickets
 {
@@ -21,7 +21,7 @@ class CheckTickets
     use SerializesModels;
 
     public function handle(
-        ExpoNotificationsService $expoNotificationsService,
+        ExpoNotificationsServiceInterface $expoNotificationsService,
         ExpoTicketStorageInterface $ticketStorage
     ): void {
         while ($ticketStorage->count() > 0) {

--- a/src/Jobs/SendPendingNotifications.php
+++ b/src/Jobs/SendPendingNotifications.php
@@ -7,9 +7,9 @@ namespace YieldStudio\LaravelExpoNotifier\Jobs;
 use Illuminate\Bus\Queueable;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\SerializesModels;
+use YieldStudio\LaravelExpoNotifier\Contracts\ExpoNotificationsServiceInterface;
 use YieldStudio\LaravelExpoNotifier\Contracts\ExpoPendingNotificationStorageInterface;
 use YieldStudio\LaravelExpoNotifier\Dto\ExpoNotification;
-use YieldStudio\LaravelExpoNotifier\ExpoNotificationsService;
 
 class SendPendingNotifications
 {
@@ -18,7 +18,7 @@ class SendPendingNotifications
     use SerializesModels;
 
     public function handle(
-        ExpoNotificationsService $expoNotificationsService,
+        ExpoNotificationsServiceInterface $expoNotificationsService,
         ExpoPendingNotificationStorageInterface $expoNotification,
     ): void {
         $sent = collect();

--- a/tests/Feature/ExpoNotificationServiceTest.php
+++ b/tests/Feature/ExpoNotificationServiceTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use YieldStudio\LaravelExpoNotifier\Contracts\ExpoNotificationsServiceInterface;
+use YieldStudio\LaravelExpoNotifier\Contracts\ExpoTicketStorageInterface;
+use YieldStudio\LaravelExpoNotifier\Dto\ExpoMessage;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->messages = collect();
+
+    for ($i = 0; $i < 120; $i++) {
+        $this->messages->push(
+            (new ExpoMessage())
+                ->to([Str::orderedUuid()->toString()])
+                ->title("A beautiful title #$i")
+                ->body('This is a content')
+                ->channelId('default')
+        );
+    }
+    $this->notificationService = app(ExpoNotificationsServiceInterface::class);
+});
+
+it("creates 2 chunks if we're sending 20 notifications above limit", function () {
+    $this->notificationService->notify($this->messages);
+    $count = $this->notificationService->getNotificationChunks()->count();
+
+    expect($count)->toBe(2)
+        ->and(app(ExpoTicketStorageInterface::class)->count())
+        ->toBe($this->messages->count());
+});

--- a/tests/Feature/Storage/ExpoPendingNotificationStorageTest.php
+++ b/tests/Feature/Storage/ExpoPendingNotificationStorageTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Collection;
+use YieldStudio\LaravelExpoNotifier\Models\ExpoNotification;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    for ($i = 0; $i < 120; $i++) {
+        ExpoNotification::create([
+            'data' => json_encode([
+                'foo' => fake()->slug,
+            ], JSON_THROW_ON_ERROR),
+        ]);
+    }
+
+    $this->notifications = ExpoNotification::all();
+    $this->notificationStorage = app(config('expo-notifications.drivers.notification'));
+});
+
+it('retrieves notifications from storage', function () {
+    $retrievedNotifications = $this->notificationStorage->retrieve();
+
+    expect($retrievedNotifications)
+        ->toBeInstanceOf(Collection::class)
+        ->and($retrievedNotifications->first()->id)
+        ->toBe($this->notifications->first()->id)
+        ->and($retrievedNotifications->first()->message->foo)
+        ->toBe(json_decode($this->notifications->first()->data, true, 512, JSON_THROW_ON_ERROR)['foo'])
+        ->and($retrievedNotifications->get(2)->id)
+        ->toBe($this->notifications->get(2)->id)
+        ->and($retrievedNotifications->get(2)->message->foo)
+        ->toBe(json_decode($this->notifications->get(2)->data, true, 512, JSON_THROW_ON_ERROR)['foo']);
+});
+
+it('retrieves a max of 100 notifications', function () {
+    $retrievedNotifications = $this->notificationStorage->retrieve();
+
+    expect($retrievedNotifications)
+        ->toBeInstanceOf(Collection::class)
+        ->and($retrievedNotifications->last()->id)
+        ->toBe(100);
+});

--- a/tests/Feature/Storage/ExpoPendingNotificationStorageTest.php
+++ b/tests/Feature/Storage/ExpoPendingNotificationStorageTest.php
@@ -12,7 +12,7 @@ beforeEach(function () {
     for ($i = 0; $i < 120; $i++) {
         ExpoNotification::create([
             'data' => json_encode([
-                'foo' => fake()->slug,
+                'foo' => $this->fake()->slug,
             ], JSON_THROW_ON_ERROR),
         ]);
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace YieldStudio\LaravelExpoNotifier\Tests;
 
+use Faker\Factory;
+use Faker\Generator;
 use Orchestra\Testbench\TestCase as Orchestra;
 use YieldStudio\LaravelExpoNotifier\Contracts\ExpoNotificationsServiceInterface;
 use YieldStudio\LaravelExpoNotifier\Contracts\ExpoPendingNotificationStorageInterface;
@@ -60,5 +62,10 @@ class TestCase extends Orchestra
             'ticket' => ExpoTicketStorageMysql::class,
             'notification' => ExpoPendingNotificationStorageMysql::class,
         ]);
+    }
+
+    protected function fake(): Generator
+    {
+        return Factory::create();
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,12 +5,60 @@ declare(strict_types=1);
 namespace YieldStudio\LaravelExpoNotifier\Tests;
 
 use Orchestra\Testbench\TestCase as Orchestra;
+use YieldStudio\LaravelExpoNotifier\Contracts\ExpoNotificationsServiceInterface;
+use YieldStudio\LaravelExpoNotifier\Contracts\ExpoPendingNotificationStorageInterface;
+use YieldStudio\LaravelExpoNotifier\Contracts\ExpoTicketStorageInterface;
+use YieldStudio\LaravelExpoNotifier\Contracts\ExpoTokenStorageInterface;
 use YieldStudio\LaravelExpoNotifier\ExpoNotificationsServiceProvider;
+use YieldStudio\LaravelExpoNotifier\FakeExpoNotificationsService;
+use YieldStudio\LaravelExpoNotifier\Storage\ExpoPendingNotificationStorageMysql;
+use YieldStudio\LaravelExpoNotifier\Storage\ExpoTicketStorageMysql;
+use YieldStudio\LaravelExpoNotifier\Storage\ExpoTokenStorageMysql;
 
-abstract class TestCase extends Orchestra
+class TestCase extends Orchestra
 {
     protected function getPackageProviders($app): array
     {
         return [ExpoNotificationsServiceProvider::class];
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app->bind(ExpoTokenStorageInterface::class, config('expo-notifications.drivers.token'));
+        $this->app->bind(ExpoTicketStorageInterface::class, config('expo-notifications.drivers.ticket'));
+        $this->app->bind(ExpoPendingNotificationStorageInterface::class, config('expo-notifications.drivers.notification'));
+
+        $this->app->bind(ExpoNotificationsServiceInterface::class, function ($app) {
+            return new FakeExpoNotificationsService(
+                'http://localhost', // won't be used, just here to respect the contract
+                'localhost', // won't be used, just here to respect the contract
+                $app->make(ExpoPendingNotificationStorageInterface::class),
+                $app->make(ExpoTicketStorageInterface::class)
+            );
+        });
+    }
+
+    protected function getEnvironmentSetUp($app): void
+    {
+        // Setup default database to use sqlite :memory:
+        config()->set('database.default', 'testbench');
+        config()->set('database.connections.testbench', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+
+        // Setup queue database connections.
+        config()->set('queue.batching.database', 'testbench');
+        config()->set('queue.failed.database', 'testbench');
+
+        // Setup Expo configuration
+        config()->set('expo-notifications.drivers', [
+            'token' => ExpoTokenStorageMysql::class,
+            'ticket' => ExpoTicketStorageMysql::class,
+            'notification' => ExpoPendingNotificationStorageMysql::class,
+        ]);
     }
 }


### PR DESCRIPTION
If you were sending more than 100 notifications (not batchable), it would failed because of the Expo Push limitation. This fix will chunk by 100 the notifications. For example, if there is 120 notifications, 2 chunks will be created and 2 requests will be sent to Expo API.

There was no test suite set up, so I had to set this first then I just wrote the test to cover the bugfix. This package is missing tests, feel free to add more :)