### PR TITLE
Add notifiable to expo notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ php artisan vendor:publish --provider="YieldStudio\LaravelExpoNotifier\ExpoNotif
 
 ## Usage
 
+### Add relation for notifiable class
+
+In order to use Notification, you need to declare the relation `expoTokens` on your Notifiable class.
+Two Trait are available to help you :
+- `HasUniqueExpoToken` if your notifiable class can have only one expo token
+- `HasManyExpoToken` if your notifiable class can have many expo token
+
 ### Send notification
 
 ```php

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ class NewSampleNotification extends Notification
         return (new ExpoMessage())
             // ->to($notifiable->expoTokens->pluck('value')->toArray()) if using HasManyExpoToken
             ->to([$notifiable->expoTokens->value])
+            ->notifiable($notifiable) // allow possibility to store the receiver of the notification
             ->title('A beautiful title')
             ->body('This is a content')
             ->channelId('default');

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ class NewSampleNotification extends Notification
     public function toExpoNotification($notifiable): ExpoMessage
     {
         return (new ExpoMessage())
+            // ->to($notifiable->expoTokens->pluck('value')->toArray()) if using HasManyExpoToken
             ->to([$notifiable->expoTokens->value])
             ->title('A beautiful title')
             ->body('This is a content')
@@ -67,6 +68,11 @@ class NewSampleNotification extends Notification
 Send database pending notifications
 ```
 php artisan expo:notifications:send
+```
+
+Clean sent notification from database
+```
+php artisan expo:notifications:clear
 ```
 
 Clean tickets from outdated tokens

--- a/database/migrations/2025_05_07_082830_update_expo_notifications_table.php
+++ b/database/migrations/2025_05_07_082830_update_expo_notifications_table.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table(config('expo-notifications.database.notifications_table_name', 'expo_notifications'), function (Blueprint $table) {
+            $table->boolean('sent')->default(false);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table(config('expo-notifications.database.notifications_table_name', 'expo_notifications'), function (Blueprint $table) {
+            $table->dropColumn('sent');
+        });
+    }
+};

--- a/database/migrations/2025_05_10_164700_update_expo_notifications_table.php
+++ b/database/migrations/2025_05_10_164700_update_expo_notifications_table.php
@@ -11,7 +11,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table(config('expo-notifications.database.notifications_table_name', 'expo_notifications'), function (Blueprint $table) {
-            $table->morphs('receiver');
+            $table->nullableMorphs('receiver');
         });
     }
 

--- a/database/migrations/2025_05_10_164700_update_expo_notifications_table.php
+++ b/database/migrations/2025_05_10_164700_update_expo_notifications_table.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table(config('expo-notifications.database.notifications_table_name', 'expo_notifications'), function (Blueprint $table) {
+            $table->morphs('receiver');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table(config('expo-notifications.database.notifications_table_name', 'expo_notifications'), function (Blueprint $table) {
+            $table->dropMorphs('receiver');
+        });
+    }
+};

--- a/src/Commands/ClearSentNotifications.php
+++ b/src/Commands/ClearSentNotifications.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YieldStudio\LaravelExpoNotifier\Commands;
+
+use Illuminate\Console\Command;
+use YieldStudio\LaravelExpoNotifier\Jobs\ClearSentNotifications as ClearSentNotificationsJob;
+
+final class ClearSentNotifications extends Command
+{
+    protected $signature = 'expo:notifications:clear';
+
+    protected $description = 'Clear sent notifications';
+
+    public function handle(): void
+    {
+        ClearSentNotificationsJob::dispatchSync();
+    }
+}

--- a/src/Contracts/ExpoPendingNotificationStorageInterface.php
+++ b/src/Contracts/ExpoPendingNotificationStorageInterface.php
@@ -10,14 +10,16 @@ use YieldStudio\LaravelExpoNotifier\Dto\ExpoNotification;
 
 interface ExpoPendingNotificationStorageInterface
 {
-    public function store(ExpoMessage $expoMessage): ExpoNotification;
+    public function store(ExpoMessage $expoMessage, bool $sent = false): ExpoNotification;
 
     /**
      * @return Collection<int, ExpoNotification>
      */
-    public function retrieve(int $amount = 100): Collection;
+    public function retrieve(int $amount = 100, bool $sent = false): Collection;
 
     public function delete(array $ids): void;
+
+    public function updateSent(array $ids, bool $sent = true): void;
 
     public function count(): int;
 }

--- a/src/Dto/ExpoMessage.php
+++ b/src/Dto/ExpoMessage.php
@@ -6,6 +6,7 @@ namespace YieldStudio\LaravelExpoNotifier\Dto;
 
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
+use Illuminate\Database\Eloquent\Model;
 
 /**
  * @see https://github.com/Alymosul/laravel-exponent-push-notifications/blob/master/src/ExpoMessage.php
@@ -44,6 +45,8 @@ final class ExpoMessage implements Arrayable, Jsonable
     public bool $mutableContent = false;
 
     public bool $shouldBatch = false;
+
+    public ?Model $notifiable = null;
 
     public static function create(): ExpoMessage
     {
@@ -155,6 +158,13 @@ final class ExpoMessage implements Arrayable, Jsonable
     public function shouldBatch(bool $shouldBatch = true): self
     {
         $this->shouldBatch = $shouldBatch;
+
+        return $this;
+    }
+
+    public function notifiable(Model $notifiable = null): self
+    {
+        $this->notifiable = $notifiable;
 
         return $this;
     }

--- a/src/Dto/ExpoNotification.php
+++ b/src/Dto/ExpoNotification.php
@@ -12,11 +12,14 @@ final class ExpoNotification implements Arrayable
 
     public ExpoMessage $message;
 
-    public static function make(int|string $id, ExpoMessage $message): ExpoNotification
+    public bool $sent;
+
+    public static function make(int|string $id, ExpoMessage $message, bool $sent): ExpoNotification
     {
         return (new ExpoNotification)
             ->id($id)
-            ->message($message);
+            ->message($message)
+            ->sent($sent);
     }
 
     public function id(int|string $value): self
@@ -33,11 +36,19 @@ final class ExpoNotification implements Arrayable
         return $this;
     }
 
+    public function sent(bool $value): self
+    {
+        $this->sent = $value;
+
+        return $this;
+    }
+
     public function toArray(): array
     {
         return [
             'id' => $this->id,
             'expo_message' => $this->message,
+            'sent' => $this->sent,
         ];
     }
 }

--- a/src/ExpoNotificationsServiceProvider.php
+++ b/src/ExpoNotificationsServiceProvider.php
@@ -7,6 +7,7 @@ namespace YieldStudio\LaravelExpoNotifier;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
 use YieldStudio\LaravelExpoNotifier\Commands\CheckTickets;
+use YieldStudio\LaravelExpoNotifier\Commands\ClearSentNotifications;
 use YieldStudio\LaravelExpoNotifier\Commands\SendPendingNotifications;
 use YieldStudio\LaravelExpoNotifier\Contracts\ExpoNotificationsServiceInterface;
 use YieldStudio\LaravelExpoNotifier\Contracts\ExpoPendingNotificationStorageInterface;
@@ -53,6 +54,7 @@ final class ExpoNotificationsServiceProvider extends ServiceProvider
         $this->commands([
             SendPendingNotifications::class,
             CheckTickets::class,
+            ClearSentNotifications::class,
         ]);
 
         if (config('expo-notifications.automatically_delete_token', false)) {

--- a/src/Jobs/ClearSentNotifications.php
+++ b/src/Jobs/ClearSentNotifications.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YieldStudio\LaravelExpoNotifier\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use YieldStudio\LaravelExpoNotifier\Contracts\ExpoPendingNotificationStorageInterface;
+
+class ClearSentNotifications
+{
+    use Dispatchable;
+    use Queueable;
+    use SerializesModels;
+
+    public function handle(
+        ExpoPendingNotificationStorageInterface $expoNotification,
+    ): void {
+        while (($sentNotifications = $expoNotification->retrieve(sent: true))->isNotEmpty()) {
+            $expoNotification->delete($sentNotifications->pluck('id')->toArray());
+        }
+    }
+}

--- a/src/Jobs/SendPendingNotifications.php
+++ b/src/Jobs/SendPendingNotifications.php
@@ -39,7 +39,7 @@ class SendPendingNotifications
             $expoNotificationsService->notify($expoMessages);
 
             $sent = $sent->merge($ids);
-            $expoNotification->delete($ids->toArray());
+            $expoNotification->updateSent($ids->toArray());
         }
     }
 }

--- a/src/Models/ExpoNotification.php
+++ b/src/Models/ExpoNotification.php
@@ -5,8 +5,14 @@ declare(strict_types=1);
 namespace YieldStudio\LaravelExpoNotifier\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
 
 class ExpoNotification extends Model
 {
     protected $guarded = ['id'];
+
+    public function receiver(): MorphTo
+    {
+        return $this->morphTo();
+    }
 }

--- a/src/Storage/ExpoPendingNotificationStorageMysql.php
+++ b/src/Storage/ExpoPendingNotificationStorageMysql.php
@@ -17,6 +17,8 @@ class ExpoPendingNotificationStorageMysql implements ExpoPendingNotificationStor
         $notification = ExpoNotification::create([
             'data' => $expoMessage->toJson(),
             'sent' => $sent,
+            'receiver_type' => $expoMessage->notifiable?->getMorphClass(),
+            'receiver_id' => $expoMessage->notifiable?->getKey(),
         ]);
 
         return ExpoNotificationDto::make($notification->id, $expoMessage, $sent);

--- a/src/Traits/HasManyExpoToken.php
+++ b/src/Traits/HasManyExpoToken.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace YieldStudio\LaravelExpoNotifier\Traits;
+
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+use YieldStudio\LaravelExpoNotifier\Models\ExpoToken;
+
+trait HasManyExpoToken
+{
+    public function expoTokens(): MorphMany
+    {
+        return $this->morphMany(ExpoToken::class, 'owner');
+    }
+}

--- a/src/Traits/HasManyExpoToken.php
+++ b/src/Traits/HasManyExpoToken.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace YieldStudio\LaravelExpoNotifier\Traits;
 
 use Illuminate\Database\Eloquent\Relations\MorphMany;
+use YieldStudio\LaravelExpoNotifier\Models\ExpoNotification;
 use YieldStudio\LaravelExpoNotifier\Models\ExpoToken;
 
 trait HasManyExpoToken
@@ -12,5 +13,10 @@ trait HasManyExpoToken
     public function expoTokens(): MorphMany
     {
         return $this->morphMany(ExpoToken::class, 'owner');
+    }
+
+    public function expoNotifications(): MorphMany
+    {
+        return $this->morphMany(ExpoNotification::class, 'receiver');
     }
 }

--- a/src/Traits/HasUniqueExpoToken.php
+++ b/src/Traits/HasUniqueExpoToken.php
@@ -4,7 +4,9 @@ declare(strict_types = 1);
 
 namespace YieldStudio\LaravelExpoNotifier\Traits;
 
+use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
+use YieldStudio\LaravelExpoNotifier\Models\ExpoNotification;
 use YieldStudio\LaravelExpoNotifier\Models\ExpoToken;
 
 trait HasUniqueExpoToken
@@ -12,5 +14,10 @@ trait HasUniqueExpoToken
     public function expoTokens(): MorphOne
     {
         return $this->morphOne(ExpoToken::class, 'owner');
+    }
+
+    public function expoNotifications(): MorphMany
+    {
+        return $this->morphMany(ExpoNotification::class, 'receiver');
     }
 }

--- a/src/Traits/HasUniqueExpoToken.php
+++ b/src/Traits/HasUniqueExpoToken.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace YieldStudio\LaravelExpoNotifier\Traits;
+
+use Illuminate\Database\Eloquent\Relations\MorphOne;
+use YieldStudio\LaravelExpoNotifier\Models\ExpoToken;
+
+trait HasUniqueExpoToken
+{
+    public function expoTokens(): MorphOne
+    {
+        return $this->morphOne(ExpoToken::class, 'owner');
+    }
+}

--- a/tests/Feature/ExpoNotificationServiceTest.php
+++ b/tests/Feature/ExpoNotificationServiceTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Str;
 use YieldStudio\LaravelExpoNotifier\Contracts\ExpoNotificationsServiceInterface;
+use YieldStudio\LaravelExpoNotifier\Contracts\ExpoPendingNotificationStorageInterface;
 use YieldStudio\LaravelExpoNotifier\Contracts\ExpoTicketStorageInterface;
 use YieldStudio\LaravelExpoNotifier\Dto\ExpoMessage;
 
@@ -32,4 +33,14 @@ it("creates 2 chunks if we're sending 20 notifications above limit", function ()
     expect($count)->toBe(2)
         ->and(app(ExpoTicketStorageInterface::class)->count())
         ->toBe($this->messages->count());
+});
+
+it("store sent notification when not using batched expo message", function () {
+    $this->notificationService->notify($this->messages);
+    $sentNotification = app(ExpoPendingNotificationStorageInterface::class)->retrieve(150, true);
+
+    expect($sentNotification->count())
+        ->toBe(120)
+        ->and($sentNotification->value('sent'))
+        ->toBeTrue();
 });


### PR DESCRIPTION
This PR follow this one : #41 

---
## Link expo notification to it's receiver
### Problem
To avoid sending multiple time the same notification for a user, we need to add an id in the data that is sent to expo and check with something like this `JSON_CONTAINS(JSON_UNQUOTE(JSON_EXTRACT(expo_notifications.data, \'$.data\')),\'"' . $user->id. '"\',\'$.user_id\')`
It is not really easy and have some performance losses.

### Solution
Add a nullableMorph `receiver` to the expo_notifications table.

close #24 

--- 

By the way, it would be nice to not set all classes as final to allow some flexibility for storing notification or anything else. I still need to use some `JSON_CONTAINS` in sql in order to keep trace of the type of notification i've send.
So extending the notification store class would allow adding a type attribute in my notification table or any other custom attributes.
it seems even more relevant when you see that you can pass any class in the package config.